### PR TITLE
Add Door_Window_M zone sensor type

### DIFF
--- a/qolsys_controller/enum.py
+++ b/qolsys_controller/enum.py
@@ -84,6 +84,7 @@ class DeviceCapability(StrEnum):
 
 class ZoneSensorType(StrEnum):
     DOOR_WINDOW = "Door_Window"
+    DOOR_WINDOW_M = "Door_Window_M"
     DOORBELL = "Doorbell"
     MOTION = "Motion"
     GLASS_BREAK = "GlassBreak"
@@ -101,7 +102,6 @@ class ZoneSensorType(StrEnum):
     FREEZE = "Freeze"
     TILT = "Tilt"
     SMOKE_M = "Smoke_M"
-    # DOOR_WINDOW_M = "" #TBD
     # OCCUPANCY = ""  #TBD
     SIREN = "Siren"
     # HIGH_TEMPERATURE = "" # TBD


### PR DESCRIPTION
I have the "PowerG Combination Door/Window Shock Sensor" which report themselves as "Door_Window_M" zone sensor type. They also provide a couple of fields ['radio_version', 'radio_id'] too.

Trying to use the Home Assistant component would crash when connecting due to this sensor type not being defined. By defining this type, I was able to connect to the panel from HA.