### PR TITLE
Add Smart Socket outlet service, test suite, and deployment tooling

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,72 @@
+# Deployment Guide
+
+## Install
+
+```bash
+sudo mkdir -p /opt/qolsys
+sudo chown $USER /opt/qolsys
+cd /opt/qolsys
+
+# uv (with MQTT bridge)
+uv venv
+uv pip install "qolsys-controller[bridge]"
+
+# --- or ---
+
+# pip (with MQTT bridge)
+python3 -m venv .venv
+.venv/bin/pip install "qolsys-controller[bridge]"
+```
+
+To install without the embedded MQTT broker (e.g. for Home Assistant):
+
+```bash
+pip install qolsys-controller
+```
+
+Both create a `.venv/` directory with the `qolsys-controller` CLI inside it.
+
+## Configure
+
+```bash
+mkdir -p config
+cp /path/to/QolsysController/config/config.json config/
+# Edit config/config.json with your panel IP, bridge settings, etc.
+```
+
+## First-Time Pairing
+
+```bash
+.venv/bin/qolsys-controller --config /opt/qolsys/config/config.json
+```
+
+> The bridge must be on the same subnet as the panel for mDNS discovery
+> during pairing. After pairing, PKI certificates are stored in
+> `config/pki/` and subnet no longer matters.
+
+## systemd Service
+
+Create a dedicated service user:
+
+```bash
+sudo useradd -r -s /usr/sbin/nologin -d /opt/qolsys qolsys
+sudo chown -R qolsys:qolsys /opt/qolsys
+```
+
+Install and enable:
+
+```bash
+sudo cp qolsys-controller.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now qolsys-controller
+journalctl -u qolsys-controller -f
+```
+
+> Edit `User`, `WorkingDirectory`, `ExecStart`, and `ReadWritePaths`
+> in the service file if your layout differs from `/opt/qolsys`.
+
+## Resilience
+
+- **Panel disconnects/reboots:** auto-reconnect with backoff
+- **systemd restart:** on-failure with 10 s delay
+- **Security hardening:** `ProtectSystem=strict`, `NoNewPrivileges=true`, `PrivateTmp=true`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,24 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
 ]
 license = "MIT"
-dependencies = []
+dependencies = [
+    "aiofiles>=25.1.0",
+    "aiomqtt>=2.5.1",
+    "cryptography>=46.0.7",
+    "passlib>=1.7.4",
+    "zeroconf>=0.148.0",
+]
+
+[project.optional-dependencies]
+bridge = [
+    "amqtt>=0.10.0",
+]
+dev = [
+    "pytest>=9.0",
+    "pytest-asyncio>=1.0",
+    "ruff",
+    "types-aiofiles",
+]
 
 [project.urls]
 Homepage = "https://github.com/EHylands/QolsysController"
@@ -26,6 +43,9 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["qolsys_controller/"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
 
 [tool.ruff]
 line-length = 127

--- a/qolsys-controller.service
+++ b/qolsys-controller.service
@@ -1,0 +1,42 @@
+# QolsysController — systemd service unit
+#
+# Create a dedicated service user:
+#   sudo useradd -r -s /usr/sbin/nologin -d /opt/qolsys qolsys
+#   sudo chown -R qolsys:qolsys /opt/qolsys
+#
+# Installation:
+#   1. Copy to /etc/systemd/system/qolsys-controller.service
+#   2. Edit User, WorkingDirectory, ExecStart to match your setup
+#   3. sudo systemctl daemon-reload
+#   4. sudo systemctl enable --now qolsys-controller
+#
+# Logs:
+#   journalctl -u qolsys-controller -f
+
+[Unit]
+Description=QolsysController — Qolsys IQ Panel bridge
+Documentation=https://github.com/EHylands/QolsysController
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=qolsys
+WorkingDirectory=/opt/qolsys
+
+# uv installs into .venv by default; pip does too with python3 -m venv .venv
+ExecStart=/opt/qolsys/.venv/bin/qolsys-controller --config /opt/qolsys/config/config.json
+
+Restart=on-failure
+RestartSec=10
+TimeoutStartSec=120
+TimeoutStopSec=10
+
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=/opt/qolsys/config
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target

--- a/qolsys_controller/automation/device.py
+++ b/qolsys_controller/automation/device.py
@@ -10,6 +10,7 @@ from qolsys_controller.automation.service_cover import CoverService
 from qolsys_controller.automation.service_light import LightService
 from qolsys_controller.automation.service_lock import LockService
 from qolsys_controller.automation.service_meter import MeterService
+from qolsys_controller.automation.service_outlet import OutletService
 from qolsys_controller.automation.service_sensor import SensorService
 from qolsys_controller.automation.service_siren import SirenService
 from qolsys_controller.automation.service_status import StatusService
@@ -26,6 +27,7 @@ from qolsys_controller.automation_zwave.service_battery import BatteryServiceZwa
 from qolsys_controller.automation_zwave.service_cover import CoverServiceZwave
 from qolsys_controller.automation_zwave.service_light import LightServiceZwave
 from qolsys_controller.automation_zwave.service_lock import LockServiceZwave
+from qolsys_controller.automation_zwave.service_outlet import OutletServiceZwave
 from qolsys_controller.automation_zwave.service_sensor import SensorServiceZwave
 from qolsys_controller.automation_zwave.service_siren import SirenServiceZwave
 from qolsys_controller.automation_zwave.service_status import StatusServiceZwave
@@ -81,6 +83,7 @@ class QolsysAutomationDevice(QolsysObservable, ABC):
             LightService,
             LockService,
             MeterService,
+            OutletService,
             SensorService,
             SirenService,
             StatusService,
@@ -117,7 +120,7 @@ class QolsysAutomationDevice(QolsysObservable, ABC):
                 pass
 
             case "Smart Socket":
-                pass
+                self.service_add_outlet_service(int(self._end_point))
 
     def info(self) -> None:
         pass
@@ -209,6 +212,23 @@ class QolsysAutomationDevice(QolsysObservable, ABC):
 
         if siren_service is not None:
             self.service_add(siren_service)
+            return
+
+    def service_add_outlet_service(self, endpoint: int = 0) -> None:
+        outlet_service: AutomationService | None = None
+
+        match self.protocol:
+            case AutomationDeviceProtocol.ADC:
+                pass
+
+            case AutomationDeviceProtocol.POWERG:
+                pass
+
+            case AutomationDeviceProtocol.ZWAVE:
+                outlet_service = OutletServiceZwave(automation_device=self, endpoint=endpoint)
+
+        if outlet_service is not None:
+            self.service_add(outlet_service)
             return
 
     def service_add_thermostat_service(self, endpoint: int = 0) -> None:

--- a/qolsys_controller/automation/service_outlet.py
+++ b/qolsys_controller/automation/service_outlet.py
@@ -1,0 +1,54 @@
+import logging
+from abc import abstractmethod
+from typing import TYPE_CHECKING, Any
+
+from qolsys_controller.automation.service import AutomationService
+from qolsys_controller.enum_qolsys import QolsysNotification
+from qolsys_controller.observable import Event
+
+if TYPE_CHECKING:
+    from qolsys_controller.automation.device import QolsysAutomationDevice
+
+LOGGER = logging.getLogger(__name__)
+
+
+class OutletService(AutomationService):
+    def __init__(self, automation_device: "QolsysAutomationDevice", endpoint: int = 0) -> None:
+        super().__init__(automation_device=automation_device, endpoint=endpoint)
+        self._service_name = "OutletService"
+        self._is_on: bool = False
+
+    @abstractmethod
+    async def turn_on(self) -> None:
+        pass
+
+    @abstractmethod
+    async def turn_off(self) -> None:
+        pass
+
+    @property
+    def is_on(self) -> bool:
+        return self._is_on
+
+    @is_on.setter
+    def is_on(self, value: bool) -> None:
+        if self._is_on != value:
+            self._is_on = value
+            self.automation_device.notify(
+                Event(QolsysNotification.AUTOMATION_UPDATE, self.automation_device, self.automation_device.to_dict_event())
+            )
+            LOGGER.debug("%s - is_on: %s", self.prefix, value)
+
+    def update_automation_service(self) -> None:
+        self.is_on = self.automation_device.status.lower() != "off"
+
+    def info(self) -> list[str]:
+        return [f"{self.prefix} - is_on: {self.is_on}"]
+
+    def to_dict_event(self) -> dict[str, Any]:
+        return {
+            "service_type": self.service_name,
+            "state": {"is_on": self.is_on},
+            "attributes": {"endpoint": self.endpoint},
+            "capabilities": {},
+        }

--- a/qolsys_controller/automation_zwave/device.py
+++ b/qolsys_controller/automation_zwave/device.py
@@ -8,6 +8,7 @@ from qolsys_controller.automation.service_sensor import SensorService
 from qolsys_controller.automation_zwave.service_light import LightServiceZwave
 from qolsys_controller.automation_zwave.service_lock import LockServiceZwave
 from qolsys_controller.automation_zwave.service_meter import MeterServiceZwave
+from qolsys_controller.automation_zwave.service_outlet import OutletServiceZwave
 from qolsys_controller.automation_zwave.service_sensor import SensorServiceZwave
 from qolsys_controller.automation_zwave.service_siren import SirenServiceZwave
 from qolsys_controller.automation_zwave.service_status import StatusServiceZwave
@@ -145,6 +146,11 @@ class QolsysAutomationDeviceZwave(QolsysAutomationDevice):
                 else:
                     LOGGER.warning("Unexpected Binary Switch value 0x%02X for node %s", payload[2], self.virtual_node_id)
 
+            # Update Outlet Service at specified endpoint
+            outlet_service = self.service_get(OutletServiceZwave, endpoint)
+            if isinstance(outlet_service, OutletServiceZwave):
+                outlet_service.is_on = payload[2] == 0xFF
+
     def parse_command_32(self, payload: bytes, endpoint: int) -> None:
         command = payload[1]
 
@@ -234,6 +240,13 @@ class QolsysAutomationDeviceZwave(QolsysAutomationDevice):
                                 self._controller, self.virtual_node_id, str(service.endpoint), [command, 0x02]
                             )
                             await zwave_command.send_command()
+
+                if isinstance(service, OutletServiceZwave):
+                    if ZwaveCommandClass.SwitchBinary in self.command_class_list:
+                        zwave_command = MQTTCommand_ZWave(
+                            self._controller, self.virtual_node_id, str(service.endpoint), [ZwaveCommandClass.SwitchBinary, 0x02]
+                        )
+                        await zwave_command.send_command()
 
     def to_dict_zwave(self) -> dict[str, str]:
         return {

--- a/qolsys_controller/automation_zwave/service_outlet.py
+++ b/qolsys_controller/automation_zwave/service_outlet.py
@@ -1,0 +1,44 @@
+import logging
+from typing import TYPE_CHECKING
+
+from qolsys_controller.automation.service_outlet import OutletService
+from qolsys_controller.enum_zwave import ZwaveCommandClass
+
+if TYPE_CHECKING:
+    from qolsys_controller.automation.device import QolsysAutomationDevice
+
+LOGGER = logging.getLogger(__name__)
+
+
+class OutletServiceZwave(OutletService):
+    def __init__(self, automation_device: "QolsysAutomationDevice", endpoint: int = 0) -> None:
+        super().__init__(automation_device=automation_device, endpoint=endpoint)
+
+    async def turn_on(self) -> None:
+        if self.is_on:
+            LOGGER.debug("%s - turn_on: already on", self.prefix)
+            return
+
+        if ZwaveCommandClass.SwitchBinary not in self.automation_device.command_class_list:  # type: ignore[attr-defined]
+            LOGGER.error("%s - outlet does not support SwitchBinary command class", self.prefix)
+            return
+
+        await self.automation_device.controller.command_zwave_switch_binary_set(
+            self.automation_device.virtual_node_id, str(self.endpoint), True
+        )
+
+    async def turn_off(self) -> None:
+        if not self.is_on:
+            LOGGER.debug("%s - turn_off: already off", self.prefix)
+            return
+
+        if ZwaveCommandClass.SwitchBinary not in self.automation_device.command_class_list:  # type: ignore[attr-defined]
+            LOGGER.error("%s - outlet does not support SwitchBinary command class", self.prefix)
+            return
+
+        await self.automation_device.controller.command_zwave_switch_binary_set(
+            self.automation_device.virtual_node_id, str(self.endpoint), False
+        )
+
+    def update_automation_service(self) -> None:
+        super().update_automation_service()

--- a/qolsys_controller/controller.py
+++ b/qolsys_controller/controller.py
@@ -205,7 +205,7 @@ class QolsysController:
             await self._mqtt_bridge.shutdown()
 
         self.connected = False
-        self.notifiy_panel_status_update()
+        self.notify_panel_status_update()
 
     def _to_event_dict(self) -> dict[str, Any]:
         return {
@@ -216,7 +216,7 @@ class QolsysController:
             "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
         }
 
-    def notifiy_panel_status_update(self) -> None:
+    def notify_panel_status_update(self) -> None:
         self.state.notify(Event(QolsysNotification.PANEL_STATUS_UPDATE, self.panel, self._to_event_dict()))
 
     async def mqtt_connect_task(self, reconnect: bool, run_forever: bool) -> None:
@@ -300,12 +300,12 @@ class QolsysController:
                     self.state.dump()
 
                 self.connected = True
-                self.notifiy_panel_status_update()
+                self.notify_panel_status_update()
                 self._task_manager.run(self.mqtt_zwave_meter_update(), self._mqtt_task_zwave_meter_update_label)
 
                 if not run_forever:
                     self.connected = False
-                    self.notifiy_panel_status_update()
+                    self.notify_panel_status_update()
                     self._task_manager.cancel(self._mqtt_task_listen_label)
                     self._task_manager.cancel(self._mqtt_task_ping_label)
                     await self.aiomqtt.__aexit__(None, None, None)
@@ -315,7 +315,7 @@ class QolsysController:
             except aiomqtt.MqttError as err:
                 # Receive pannel network error
                 self.connected = False
-                self.notifiy_panel_status_update()
+                self.notify_panel_status_update()
                 self.aiomqtt = None
 
                 if reconnect:
@@ -329,7 +329,7 @@ class QolsysController:
                 # We cannot recover from this error automaticly
                 # Pannels need to be re-paired
                 self.connected = False
-                self.notifiy_panel_status_update()
+                self.notify_panel_status_update()
                 self.aiomqtt = None
                 raise QolsysSslError from err
 
@@ -385,7 +385,7 @@ class QolsysController:
 
         except aiomqtt.MqttError as err:
             self.connected = False
-            self.notifiy_panel_status_update()
+            self.notify_panel_status_update()
 
             LOGGER.debug("%s: Listen - Reconnecting in %s seconds ...", err, self.settings.mqtt_timeout)
             await asyncio.sleep(self.settings.mqtt_timeout)

--- a/qolsys_controller/enum_qolsys.py
+++ b/qolsys_controller/enum_qolsys.py
@@ -105,7 +105,9 @@ class ZoneStatus(StrEnum):
     TAMPERED = "Tampered"
     SYNCHRONIZING = "Synchronizing"
     DISCONNECTED = "disconnected"
+    HIGH_TEMP_ALERT = "High Temp Alert"
     TROUBLE = "Trouble"
+    UNKNOWN = "Unknown"
     VACANT = "Vacant"
 
 
@@ -213,6 +215,11 @@ class ZoneSensorGroup(StrEnum):
     STAY_INSTANT_MOTION = "stayinstantmotion"
     STAY_DELAY_MOTION = "staydelaymotion"
     AWAY_DELAY_MOTION = "awaydelaymotion"
+    SHOCK_AWAY_ONLY = "shockawayonly"
+    SIREN = "Siren"
+    TEMPERATURE = "Temperature"
+    TEMPERATURE_CMS = "Temperature CMS"
+    TRANSLATOR = "translator"
     WATER = "WaterSensor"
     WATER_NON_REPORTING = "Water_Non_Reporting"
 

--- a/qolsys_controller/mqtt_bridge/bridge.py
+++ b/qolsys_controller/mqtt_bridge/bridge.py
@@ -91,8 +91,8 @@ class MqttBridge:
 
     @property
     def panel_unique_id(self) -> str:
-        if self._controller.settings._mqtt_bridge_friendly_name != "":
-            return self._controller.settings._mqtt_bridge_friendly_name
+        if self._controller.settings.mqtt_bridge_friendly_name != "":
+            return self._controller.settings.mqtt_bridge_friendly_name
         return self._controller.panel.unique_id
 
     @property
@@ -101,7 +101,7 @@ class MqttBridge:
 
     @property
     def base_topic(self) -> str:
-        return f"{self._controller.settings._mqtt_bridge_root_topic}/v{self.version}/{self.panel_unique_id}"
+        return f"{self._controller.settings.mqtt_bridge_root_topic}/v{self.version}/{self.panel_unique_id}"
 
     @property
     def automation_topic(self) -> str:

--- a/qolsys_controller/mqtt_bridge/broker.py
+++ b/qolsys_controller/mqtt_bridge/broker.py
@@ -21,8 +21,8 @@ class MqttBridgeBroker:
     def __init__(self, bridge: "MqttBridge") -> None:
         self._bridge: MqttBridge = bridge
         self._controller: QolsysController = bridge._controller
-        self._config: dict[str, Any] = self._build_config()
-        self._broker = self._create_broker()
+        self._config: dict[str, Any] = {}
+        self._broker: Any = None
         self._is_running: bool = False
         self._broker_task: asyncio.Task[None] | None = None
         self._stop_event = asyncio.Event()
@@ -53,7 +53,7 @@ class MqttBridgeBroker:
         LOGGER.info(
             "MQTT Bridge Broker: Starting: %s:%s ...",
             self._controller.settings.plugin_ip,
-            self._controller.settings._mqtt_bridge_port,
+            self._controller.settings.mqtt_bridge_port,
         )
 
         startup_event = asyncio.Event()
@@ -84,6 +84,12 @@ class MqttBridgeBroker:
         try:
             if self._controller.settings.mqtt_bridge_tls_enabled:
                 await self._check_or_create_certificates()
+            self._config = self._build_config()
+            self._broker = self._create_broker()
+            if self._broker is None:
+                startup_result["started"] = False
+                startup_event.set()
+                return
             await self._broker.start()
             await self.wait_for_broker_start()
             self._broker.on_client_connected = self._on_client_connected
@@ -159,16 +165,18 @@ class MqttBridgeBroker:
         if not self._controller.settings.mqtt_bridge_enabled:
             return {}
 
-        listeners = {
-            "default": {
-                "type": "tcp",
-                "bind": f"{self._controller.settings.plugin_ip}:{self._controller.settings.mqtt_bridge_port}",
-                "ssl": self._controller.settings.mqtt_bridge_tls_enabled,
-                "max_connections": self._controller.settings.mqtt_bridge_max_connections,
-                "certfile": str(self._controller._pki.mqtt_bridge_cer_file_path),
-                "keyfile": str(self._controller._pki.mqtt_bridge_key_file_path),
-            }
+        listener: dict[str, Any] = {
+            "type": "tcp",
+            "bind": f"{self._controller.settings.plugin_ip}:{self._controller.settings.mqtt_bridge_port}",
+            "ssl": self._controller.settings.mqtt_bridge_tls_enabled,
+            "max_connections": self._controller.settings.mqtt_bridge_max_connections,
         }
+
+        if self._controller.settings.mqtt_bridge_tls_enabled:
+            listener["certfile"] = str(self._controller._pki.mqtt_bridge_cer_file_path)
+            listener["keyfile"] = str(self._controller._pki.mqtt_bridge_key_file_path)
+
+        listeners = {"default": listener}
 
         # Plugin selection
         plugins: dict[str, dict[str, Any]] = {}

--- a/qolsys_controller/mqtt_bridge/client.py
+++ b/qolsys_controller/mqtt_bridge/client.py
@@ -12,6 +12,7 @@ from qolsys_controller.automation.service import AutomationService
 from qolsys_controller.automation.service_cover import CoverService
 from qolsys_controller.automation.service_light import LightService
 from qolsys_controller.automation.service_lock import LockService
+from qolsys_controller.automation.service_outlet import OutletService
 from qolsys_controller.automation.service_siren import SirenService
 from qolsys_controller.automation.service_thermostat import ThermostatService
 from qolsys_controller.automation.service_valve import ValveService
@@ -86,7 +87,7 @@ class MqttBridgeClient:
                     password=self._bridge._internal_password,
                     protocol=ProtocolVersion.V311,
                     hostname=self._bridge._controller.settings.plugin_ip,
-                    port=self._bridge._controller.settings._mqtt_bridge_port,
+                    port=self._bridge._controller.settings.mqtt_bridge_port,
                     tls_context=tls_context if self._bridge._controller.settings.mqtt_bridge_tls_enabled else None,
                     identifier=self._client_id,
                 ) as self._client:
@@ -308,6 +309,8 @@ class MqttBridgeClient:
             "COVER_POSITION": self._cmd_cover_position,
             "SIREN_ON": self._cmd_siren_on,
             "SIREN_OFF": self._cmd_siren_off,
+            "OUTLET_ON": self._cmd_outlet_on,
+            "OUTLET_OFF": self._cmd_outlet_off,
             "VALVE_OPEN": self._cmd_valve_open,
             "VALVE_CLOSE": self._cmd_valve_close,
             "VALVE_STOP": self._cmd_valve_stop,
@@ -520,7 +523,7 @@ class MqttBridgeClient:
                 response_dict = {
                     "success": False,
                     "error": "valve_position_missing",
-                    "error_msg": "Automation Command - Missing position for {command} command",
+                    "error_msg": f"Automation Command - Missing position for {command} command",
                     "command_id": command_id,
                 }
 
@@ -690,6 +693,18 @@ class MqttBridgeClient:
     async def _cmd_siren_off(self, device: QolsysAutomationDevice, endpoint: int, data: dict[str, Any]) -> None:
         service = await self._get_service(device, SirenService, endpoint, data)
         if isinstance(service, SirenService):
+            await service.turn_off()
+            await self._send_success(data)
+
+    async def _cmd_outlet_on(self, device: QolsysAutomationDevice, endpoint: int, data: dict[str, Any]) -> None:
+        service = await self._get_service(device, OutletService, endpoint, data)
+        if isinstance(service, OutletService):
+            await service.turn_on()
+            await self._send_success(data)
+
+    async def _cmd_outlet_off(self, device: QolsysAutomationDevice, endpoint: int, data: dict[str, Any]) -> None:
+        service = await self._get_service(device, OutletService, endpoint, data)
+        if isinstance(service, OutletService):
             await service.turn_off()
             await self._send_success(data)
 

--- a/qolsys_controller/panel.py
+++ b/qolsys_controller/panel.py
@@ -931,12 +931,15 @@ class QolsysPanel:
                     "Water Valve",
                 ]:
                     zwave_id = zwave_device.get("node_id", "")
-                    for temp_device in automation_devices:
-                        if temp_device.virtual_node_id == zwave_id:
-                            LOGGER.debug(
-                                "AutDev%s: Z-Wave device with the same virtual_node_id already exists, skipping", zwave_id
-                            )
-                            break
+                    if not zwave_id:
+                        LOGGER.debug("Skipping Z-Wave device with empty node_id")
+                        continue
+
+                    if any(d.virtual_node_id == zwave_id for d in automation_devices):
+                        LOGGER.debug(
+                            "AutDev%s: Z-Wave device with the same virtual_node_id already exists, skipping", zwave_id
+                        )
+                        continue
 
                     new_zwave_device = QolsysAutomationDeviceZwave(self._controller, zwave_device, {})
                     new_zwave_device.virtual_node_id = zwave_id
@@ -948,10 +951,14 @@ class QolsysPanel:
             adc_devices = self.db.get_adc_devices()
             for adc_device in adc_devices:
                 adc_id = adc_device.get("device_id", "")
-                for temp_device in automation_devices:
-                    if temp_device.virtual_node_id == adc_id:
-                        LOGGER.debug("AutDev%s: ADC device with the same virtual_node_id already exists, skipping", adc_id)
-                        break
+                if not adc_id:
+                    LOGGER.debug("Skipping ADC device with empty device_id")
+                    continue
+
+                if any(d.virtual_node_id == adc_id for d in automation_devices):
+                    LOGGER.debug("AutDev%s: ADC device with the same virtual_node_id already exists, skipping", adc_id)
+                    continue
+
                 new_adc_device = QolsysAutomationDeviceADC(self._controller, adc_device)
                 automation_devices.append(new_adc_device)
 

--- a/qolsys_controller/zone.py
+++ b/qolsys_controller/zone.py
@@ -20,7 +20,11 @@ class QolsysZone(QolsysObservable):
 
         self._zone_id: str = data.get("zoneid", "")
         self._sensorname: str = data.get("sensorname", "")
-        self._sensorstatus: ZoneStatus = ZoneStatus(data.get("sensorstatus", ""))
+        try:
+            self._sensorstatus: ZoneStatus = ZoneStatus(data.get("sensorstatus", ""))
+        except ValueError:
+            self._sensorstatus = ZoneStatus.UNKNOWN
+            LOGGER.warning("Unknown ZoneStatus: %s", data.get("sensorstatus", ""))
         self._sensorgroup: str = data.get("sensorgroup", "")
         self._battery_status: str = data.get("battery_status", "")
         self._averagedBm: str = data.get("averagedBm", "")
@@ -170,7 +174,10 @@ class QolsysZone(QolsysObservable):
             self.sensorname = data.get("sensorname", "")
 
         if "sensorstatus" in data:
-            self.sensorstatus = ZoneStatus(data.get("sensorstatus", ""))
+            try:
+                self.sensorstatus = ZoneStatus(data.get("sensorstatus", ""))
+            except ValueError:
+                LOGGER.warning("Unknown ZoneStatus: %s", data.get("sensorstatus", ""))
 
         if "battery_status" in data:
             self.battery_status = data.get("battery_status", "")
@@ -552,6 +559,15 @@ class QolsysZone(QolsysObservable):
             "parent_node": self._parent_node,
         }
 
+    def _safe_sensor_group(self) -> str:
+        if not self.sensorgroup:
+            return "unknown"
+        try:
+            return ZoneSensorGroup(self.sensorgroup).name.lower()
+        except ValueError:
+            LOGGER.warning("Unknown ZoneSensorGroup: %s, please report", self.sensorgroup)
+            return self.sensorgroup
+
     def to_dict_event(self) -> dict[str, Any]:
         payload: dict[str, Any] = {
             "id": int(self.zone_id),
@@ -573,8 +589,8 @@ class QolsysZone(QolsysObservable):
             "attributes": {
                 "name": self.sensorname,
                 "device_type": self.sensortype.name.lower(),
-                "partition_id": int(self.partition_id),
-                "group": ZoneSensorGroup(self.sensorgroup).name.lower(),
+                "partition_id": int(self.partition_id) if self.partition_id else 0,
+                "group": self._safe_sensor_group(),
             },
             "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
             "version": 1,

--- a/tests/test_outlet_service.py
+++ b/tests/test_outlet_service.py
@@ -1,0 +1,62 @@
+"""Tests for OutletService and OutletServiceZwave."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from qolsys_controller.automation_zwave.service_outlet import OutletServiceZwave
+from qolsys_controller.enum_zwave import ZwaveCommandClass
+
+
+def _make_mock_device() -> MagicMock:
+    device = MagicMock()
+    device.virtual_node_id = "8"
+    device.device_name = "Smart Plug"
+    device.protocol.name = "ZWAVE"
+    device.controller = MagicMock()
+    device.controller.command_zwave_switch_binary_set = AsyncMock()
+    device.status = "off"
+    device.command_class_list = [ZwaveCommandClass.SwitchBinary]
+    device.to_dict_event.return_value = {}
+    return device
+
+
+class TestOutletServiceZwave:
+    def test_update_status_on(self) -> None:
+        device = _make_mock_device()
+        device.status = "on"
+        service = OutletServiceZwave(automation_device=device, endpoint=0)
+        service.update_automation_service()
+        assert service.is_on is True
+
+    @pytest.mark.asyncio
+    async def test_turn_on(self) -> None:
+        device = _make_mock_device()
+        service = OutletServiceZwave(automation_device=device, endpoint=0)
+        service._is_on = False
+        await service.turn_on()
+        device.controller.command_zwave_switch_binary_set.assert_awaited_once_with("8", "0", True)
+
+    @pytest.mark.asyncio
+    async def test_turn_on_already_on_skips(self) -> None:
+        device = _make_mock_device()
+        service = OutletServiceZwave(automation_device=device, endpoint=0)
+        service._is_on = True
+        await service.turn_on()
+        device.controller.command_zwave_switch_binary_set.assert_not_awaited()
+
+    def test_is_on_notifies(self) -> None:
+        device = _make_mock_device()
+        service = OutletServiceZwave(automation_device=device, endpoint=0)
+        service.is_on = True
+        device.notify.assert_called_once()
+
+    def test_to_dict_event(self) -> None:
+        device = _make_mock_device()
+        service = OutletServiceZwave(automation_device=device, endpoint=0)
+        service._is_on = True
+        result = service.to_dict_event()
+        assert result["service_type"] == "OutletService"
+        assert result["state"]["is_on"] is True

--- a/tests/test_partition.py
+++ b/tests/test_partition.py
@@ -1,0 +1,53 @@
+"""Tests for QolsysPartition — alarm type mapping and updates."""
+
+from __future__ import annotations
+
+from qolsys_controller.enum_qolsys import PartitionAlarmState, PartitionAlarmType, PartitionSystemStatus
+from qolsys_controller.partition import QolsysPartition
+
+
+def _make_partition(**overrides: object) -> QolsysPartition:
+    partition_dict = {"partition_id": "0", "name": "Home", "devices": ""}
+    settings_dict = {
+        "SYSTEM_STATUS": "DISARM",
+        "SYSTEM_STATUS_CHANGED_TIME": "",
+        "EXIT_SOUNDS": "ON",
+        "ENTRY_DELAYS": "ON",
+    }
+    partition_dict.update(overrides.get("partition", {}))
+    settings_dict.update(overrides.get("settings", {}))
+    return QolsysPartition(
+        partition_dict,
+        settings_dict,
+        alarm_state=overrides.get("alarm_state", PartitionAlarmState.NONE),
+        alarm_type_array=overrides.get("alarm_types", []),
+    )
+
+
+class TestAlarmTypeMapping:
+    def test_glass_break_maps_to_police(self) -> None:
+        partition = _make_partition()
+        partition.append_alarm_type([PartitionAlarmType.GLASS_BREAK])
+        assert PartitionAlarmType.POLICE_EMERGENCY in partition.alarm_type_array
+
+    def test_smoke_heat_maps_to_fire(self) -> None:
+        partition = _make_partition()
+        partition.append_alarm_type([PartitionAlarmType.SMOKE_HEAT])
+        assert PartitionAlarmType.FIRE_EMERGENCY in partition.alarm_type_array
+
+    def test_duplicate_alarm_types_deduped(self) -> None:
+        partition = _make_partition()
+        partition.append_alarm_type([PartitionAlarmType.GLASS_BREAK, PartitionAlarmType.ENTRY_EXIT_NORMAL_DELAY])
+        assert partition.alarm_type_array.count(PartitionAlarmType.POLICE_EMERGENCY) == 1
+
+
+class TestPartitionUpdate:
+    def test_update_system_status(self) -> None:
+        partition = _make_partition()
+        partition.update_settings({"SYSTEM_STATUS": "ARM-STAY"})
+        assert partition.system_status == PartitionSystemStatus.ARM_STAY
+
+    def test_update_wrong_partition_ignored(self) -> None:
+        partition = _make_partition()
+        partition.update_partition({"partition_id": "99", "name": "Hacked"})
+        assert partition.name == "Home"

--- a/tests/test_zone.py
+++ b/tests/test_zone.py
@@ -1,0 +1,77 @@
+"""Tests for QolsysZone — property setters, update parsing, and PowerG attributes."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from qolsys_controller.enum_qolsys import ZoneSensorType
+from qolsys_controller.zone import QolsysZone
+
+
+def _make_settings(**overrides: object) -> MagicMock:
+    settings = MagicMock()
+    settings.motion_sensor_delay = False
+    settings.motion_sensor_delay_sec = 310
+    for k, v in overrides.items():
+        setattr(settings, k, v)
+    return settings
+
+
+def _make_zone(data: dict[str, str] | None = None, **kw: object) -> QolsysZone:
+    defaults: dict[str, str] = {
+        "zoneid": "1",
+        "sensorname": "Front Door",
+        "sensorstatus": "Closed",
+        "sensortype": "Door_Window",
+        "sensorgroup": "entryexitdelay",
+        "partition_id": "0",
+    }
+    if data:
+        defaults.update(data)
+    return QolsysZone(defaults, _make_settings(**kw))
+
+
+class TestZoneSetters:
+    def test_set_partition_id(self) -> None:
+        zone = _make_zone()
+        zone.partition_id = "1"
+        assert zone.partition_id == "1"
+
+    def test_latestdBm_out_of_range(self) -> None:
+        zone = _make_zone({"latestdBm": "999"})
+        assert zone.latestdBm is None
+
+
+class TestZoneUpdate:
+    def test_update_sensortts(self) -> None:
+        zone = _make_zone()
+        zone.update({"zoneid": "1", "sensortts": "12345"})
+        assert zone._sensortts == "12345"
+
+    def test_update_wrong_zone_id_ignored(self) -> None:
+        zone = _make_zone()
+        zone.update({"zoneid": "999", "sensorname": "Hacked"})
+        assert zone.sensorname == "Front Door"
+
+
+class TestPowerg:
+    def test_extras_bad_json_ignored(self) -> None:
+        zone = _make_zone({"shortID": "42"})
+        zone.update_powerg({"shortID": "42", "extras": "not-json"})
+        assert zone._powerg_extras == ""
+
+    def test_temperature_rounding(self) -> None:
+        zone = _make_zone()
+        zone._powerg_temperature = "22.456"
+        assert zone.powerg_temperature == 22.5
+
+    def test_battery_voltage_millivolts(self) -> None:
+        zone = _make_zone()
+        zone._powerg_battery_voltage = "3200"
+        assert zone.powerg_battery_voltage == 3.2
+
+
+class TestUnknownSensorType:
+    def test_unknown_type_defaults(self) -> None:
+        zone = _make_zone({"sensortype": "SomeNewType"})
+        assert zone.sensortype == ZoneSensorType.UNKNOWN


### PR DESCRIPTION
- Implement OutletService / OutletServiceZwave for Smart Socket devices (the only unimplemented device type)
- Add the project's first test suite (18 tests covering zones, partitions, and the outlet service)
- Fix a few bugs found during development
- Add deployment guide and systemd service unit
- Add missing runtime dependencies to pyproject.toml