### PR TITLE
fix: adding pgm_outputs table in database definition

### DIFF
--- a/qolsys_controller/database/table_pgm_outputs.py
+++ b/qolsys_controller/database/table_pgm_outputs.py
@@ -12,11 +12,18 @@ class QolsysTablePgmOutputs(QolsysTable):
         self._uri = "content://com.qolsys.qolsysprovider.PgmOutputsContentProvider/pgm_outputs"
         self._table = "pgm_outputs"
         self._abort_on_error = False
-        self._implemented = False
+        self._implemented = True
         self._report_new_columns = True
 
         self._columns = [
             "_id",
+            "version",
+            "opr",
+            "partition_id",
+            "w2w_zoneID",
+            "pgm_number",
+            "name",
+            "state",
         ]
 
         self._create_table()


### PR DESCRIPTION
fix: adding pgm_outputs table in database definition